### PR TITLE
Update Font to Manrope

### DIFF
--- a/apps/client/app/globals.css
+++ b/apps/client/app/globals.css
@@ -8,8 +8,7 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-manrope);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -22,5 +21,5 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-manrope), sans-serif;
 }

--- a/apps/client/app/layout.tsx
+++ b/apps/client/app/layout.tsx
@@ -1,16 +1,11 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Manrope } from "next/font/google";
 import "./globals.css";
 import Footer from "../components/Footer";
 import Header from "../components/Header";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const manrope = Manrope({
+  variable: "--font-manrope",
   subsets: ["latin"],
 });
 
@@ -27,7 +22,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${manrope.variable} antialiased`}
       >
         <Header />
         {children}


### PR DESCRIPTION
## Summary
Replaced Geist font with Manrope across the project:
- Updated `globals.css` to use Manrope font variable
- Modified `layout.tsx` to import and configure Manrope font
- Removed Geist Sans and Geist Mono font imports
- Updated font family in body and theme inline styles 
  


 <br /> 


 > Want tembo to make any changes? Add a review or comment with `@tembo` and i'll get back to work! 


 [![tembo.io](https://internal.tembo.io/static/view/tembo.svg?v=5)](https://app.tembo.io/tasks/29b36dcb-6701-41e9-8103-12d3cd977e3c)  [![app.tembo.io](https://internal.tembo.io/public/agent-button/claudeCode:claude-opus-4-5?v=1)](https://app.tembo.io/settings/agents)